### PR TITLE
Escape '/' characters in Authorization header.

### DIFF
--- a/oauth_hook/hook.py
+++ b/oauth_hook/hook.py
@@ -143,7 +143,7 @@ class OAuthHook(object):
     def authorization_header(oauth_params):
         """Return Authorization header"""
         authorization_headers = 'OAuth realm="",'
-        authorization_headers += ','.join(['{0}="{1}"'.format(k, urllib.quote(str(v)))
+        authorization_headers += ','.join(['{0}="{1}"'.format(k, urllib.quote(str(v), ''))
             for k, v in oauth_params.items()])
         return authorization_headers
 


### PR DESCRIPTION
Escape '/' characters in Authorization header. These can occur in the B64-encoded oauth_signature. See Section 5.4.1 of the OAuth 1.0 spec: http://oauth.net/core/1.0/#auth_header
