### PR TITLE
Initial attempt at an RPM makefile and the required setup.py changes

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,1 @@
-include README.md LICENSE
+include README.md LICENSE AUTHORS version.txt

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,24 @@
+version:
+	git describe --tags > version.txt
+	perl -p -i -e 's/-/_/g' version.txt
+
+sdist:
+	python setup.py sdist
+
+signed-rpm: sdist version
+	rpmbuild -ba python-requests-oauth.spec --sign --define "_sourcedir `pwd`/dist"
+
+rpm: sdist version
+	rpmbuild -ba python-requests-oauth.spec --define "_sourcedir `pwd`/dist"
+
+srpm: sdist version
+	rpmbuild -bs python-requests-oauth.spec --define "_sourcedir `pwd`/dist"
+
+pylint:
+	pylint --rcfile=pylint.conf oauth_hook
+
+unittests:
+	python -m unittest discover -v
+
+clean:
+	rm -rf MANIFEST build dist python-requests-oauth.spec version.txt

--- a/python-requests-oauth.spec.in
+++ b/python-requests-oauth.spec.in
@@ -1,0 +1,78 @@
+#%if 0%{?fedora} > 12 || 0%{?rhel} > 6
+#TODO: Revisit this if requests-oauth becomes Python 3 clean
+%global _with_python3 0
+#%else
+#%{!?python_sitelib: %global python_sitelib %(%{__python} -c "from distutils.sysconfig import get_python_lib; print (get_python_lib())")}
+#%endif
+
+Name:           python-requests-oauth
+Version:        @VERSION@
+Release:        1%{?dist}
+Summary:        Hook for adding Open Authentication support to Python-requests HTTP library.
+
+License:        BSD
+URL:            http://pypi.python.org/pypi/requests-oauth
+Source0:        http://pypi.python.org/packages/source/r/requests-oauth/requests-oauth-%{version}.tar.gz
+
+
+BuildArch:      noarch
+BuildRequires:  python-devel
+BuildRequires:  python-setuptools
+Requires:       python-requests >= 0.12.1
+
+%description
+This plugins adds OAuth v1.0 support to Kenneth Reitz's well-known requests library for Python, providing both header and url-encoded authentication.
+
+requests-oauth wants to provide the simplest and easiest way to do OAuth in Python. It was initially based on python-oauth2 (which looks unmaintained), kudos to the authors and contributors for doing a huge effort in providing OAuth to python httplib2. From that point on, the code base has been cleaned, fixing several bugs and heavily refactoring it to eliminate dependencies with python-oauth2, being now a stand-alone plugin.
+
+
+%if 0%{?_with_python3}
+%package -n python3-requests-oauth
+Summary: HTTP library, written in Python, for human beings
+BuildRequires: python3-devel
+BuildRequires: python3-setuptools
+%description -n python3-requests-oauth
+This plugins adds OAuth v1.0 support to Kenneth Reitz's well-known requests library for Python, providing both header and url-encoded authentication.
+
+requests-oauth wants to provide the simplest and easiest way to do OAuth in Python. It was initially based on python-oauth2 (which looks unmaintained), kudos to the authors and contributors for doing a huge effort in providing OAuth to python httplib2. From that point on, the code base has been cleaned, fixing several bugs and heavily refactoring it to eliminate dependencies with python-oauth2, being now a stand-alone plugin.
+%endif
+
+
+%prep
+%setup -n requests-oauth-%{version}
+
+%build
+%{__python} setup.py build
+%if 0%{?_with_python3}
+%{__python3} setup.py build
+%endif
+
+
+%install
+rm -rf $RPM_BUILD_ROOT
+%{__python} setup.py install -O1 --skip-build --root $RPM_BUILD_ROOT
+%if 0%{?_with_python3}
+%{__python3} setup.py install -O1 --skip-build --root $RPM_BUILD_ROOT
+%endif
+
+# TODO: Perhaps not include the tests as a top level module?
+[ -d $RPM_BUILD_ROOT/%{python_sitelib}/tests ] && rm -rf $RPM_BUILD_ROOT/%{python_sitelib}/tests
+ 
+%files
+%defattr(-,root,root,-)
+%doc LICENSE README.md AUTHORS
+%{python_sitelib}/requests_oauth*.egg-info
+%dir %{python_sitelib}/oauth_hook
+%{python_sitelib}/oauth_hook/*
+
+%if 0%{?_with_python3}
+%files -n python3-requests-oauth
+%{python3_sitelib}/requests_oauth*.egg-info
+%dir %{python3_sitelib}/oauth_hook
+%{python3_sitelib}/oauth_hook/*
+%endif
+
+
+%changelog
+* Tue Sep 25 2012 Ian McLeod <imcleod@redhat.com> 0.4.1-1
+- Initial RPM build

--- a/setup.py
+++ b/setup.py
@@ -2,12 +2,57 @@
 # -*- coding: utf-8 -*-
 
 from setuptools import setup, find_packages
+from setuptools.command.sdist import sdist as _sdist
+import os
+import os.path
+import subprocess
+import re
 
 version = '0.4.1'
 
+# Required for Python 2.6 backwards compat
+def subprocess_check_output(*popenargs, **kwargs):
+    if 'stdout' in kwargs:
+        raise ValueError('stdout argument not allowed, it will be overridden.')
+
+    process = subprocess.Popen(stdout=subprocess.PIPE, stderr=subprocess.STDOUT, *popenargs, **kwargs)
+    stdout, stderr = process.communicate()
+    retcode = process.poll()
+    if retcode:
+        cmd = ' '.join(*popenargs)
+        raise Exception("'%s' failed(%d): %s" % (cmd, retcode, stderr))
+    return (stdout, stderr, retcode) 
+
+pkg_version = None
+
+try:
+    (pkg_version, ignore, ignore) = subprocess_check_output('/usr/bin/git describe | tr - _', shell=True)
+    pkg_version = pkg_version.rstrip('\n')
+except:
+    pass
+
+fatal_error = re.compile('fatal')
+if fatal_error.search(pkg_version):
+    # If we are not in an active git tree assume we are in a source distribution and get the saved version.txt
+    try:
+        (pkg_version, ignore, ignore) = subprocess_check_output('cat version.txt', shell=True)
+    except:
+        print 'WARNING: Cannot get package version from git or in tree - setting to hardcode setup.py version (%s)' % (version)
+        pkg_version = version
+
+def modify_specfile():
+    cmd = (' sed -e "s/@VERSION@/%s/g" < python-requests-oauth.spec.in ' % pkg_version) + " > python-requests-oauth.spec"
+    os.system(cmd)
+
+class sdist(_sdist):
+    """ custom sdist command to prepare python-requests-oauth.spec file """
+    def run(self):
+        modify_specfile()
+        _sdist.run(self)
+
 setup(
     name='requests-oauth',
-    version=version,
+    version=pkg_version,
     description='Hook for adding Open Authentication support to Python-requests HTTP library.',
     long_description=open('README.md').read(),
     author='Miguel Araujo',
@@ -27,4 +72,5 @@ setup(
     ),
     keywords=['requests', 'python-requests', 'OAuth', 'open authentication'],
     zip_safe=False,
+    cmdclass = {'sdist': sdist},
 )


### PR DESCRIPTION
As the commit title suggests, this is an initial effort at making an RPM that can be included in Fedora or other RPM based distros.

This includes a scheme I originally borrowed from the Oz project that creates a version string based on the output of "git describe".  This only works correctly if you have at least one annotated tag in your repo
and ideally should be used by annotating all major release tags like this:

git tag -m "0.4.2" 0.4.2

I have an annotated tag in my fork which may or may not carry forward with this pull request.  If it doesn't you may need to create one using the scheme above in order for this code to work as expected.

If all is well, checkout followed by "make rpm" should produce some sensible RPM output.
